### PR TITLE
Rename *Gui.Execute() to *Gui.Update()

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -89,7 +89,7 @@ func (ui *UI) listenForPayloads(g *gocui.Gui) error {
 
 func writeMessage(g *gocui.Gui, msg string) {
 	logrus.Debug("Redrawing UI with new message")
-	g.Execute(func(g *gocui.Gui) error {
+	g.Update(func(g *gocui.Gui) error {
 		v, err := g.View("messages")
 		if err != nil {
 			return err


### PR DESCRIPTION
This is necessary in order to work because of this update https://github.com/jroimartin/gocui/commit/6564cfcacb01db61e3a4e983405a598db3e91982 from `gocui`